### PR TITLE
Add missing HIRC types; add name dehashing for reversable types

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -152,6 +152,9 @@
 							<DataGridTextColumn Header="ID"
 												Binding="{Binding Id}"
 												IsReadOnly="True"/>
+                            <DataGridTextColumn Header="Name"
+												Binding="{Binding StringId}"
+												IsReadOnly="True"/>
 							<DataGridTextColumn Header="Size"
 												Binding="{Binding Size, StringFormat={}{0:d} B}"
 												IsReadOnly="True"/>

--- a/SoundBank/Sections/HircObjects/Action.cs
+++ b/SoundBank/Sections/HircObjects/Action.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PD2SoundBankEditor {
+	public class Action : HircObject {
+		public byte ActionScope;
+		public byte ActionType;
+        public string ActionScopeString
+        {
+            get => ActionScope switch
+            {
+                0x01 => "Object: Switch or Trigger",
+                0x02 => "Global",
+                0x03 => "Object",
+                0x04 => "Object: State",
+                0x05 => "All",
+                0x09 => "All Except Referenced",
+                _ => "Unknown"
+            };
+        }
+        public string ActionTypeString
+        {
+            get => ActionType switch
+            {
+                0x01 => "Stop",
+                0x02 => "Pause",
+                0x03 => "Resume",
+                0x04 => "Play",
+                0x05 => "Trigger",
+                0x06 => "Mute",
+                0x07 => "Unmute",
+                0x08 => "Set Voice Pitch",
+                0x09 => "Reset Voice Pitch",
+                0x0A => "Set Voice Volume",
+                0x0B => "Reset Voice Volume",
+                0x0C => "Set Bus Volume",
+                0x0D => "Reset Bus Volume",
+                0x0E => "Set Voice Low-pass Filter",
+                0x0F => "Reset Voice Low-pass Filter",
+                0x10 => "Enable State",
+                0x11 => "Disable State",
+                0x12 => "Set State",
+                0x13 => "Set Game Parameter",
+                0x14 => "Reset Game Parameter",
+                0x19 => "Set Switch",
+                0x1A => "Enable/Disable Bypass",
+                0x1B => "Reset Bypass Effect",
+                0x1C => "Break",
+                0x1E => "Seek",
+                _ => "Unknown"
+            };
+        }
+
+        public uint ObjectId;
+		public byte ParameterNumber;
+		public Dictionary<byte, byte[]> Parameters = new();
+
+        public uint SwitchGroupId;
+        public uint SwitchId;
+		
+		public byte[] Unhandled;
+
+		public Action(HircSection section, byte type, BinaryReader reader) : base(section, type, reader) { }
+
+		public override void Read(BinaryReader reader, int amount) {
+			var dataOffset = (int)reader.BaseStream.Position;
+
+			ActionScope = reader.ReadByte();
+
+			ActionType = reader.ReadByte();
+			ObjectId = reader.ReadUInt32();
+			reader.ReadByte(); // Always 00
+
+			ParameterNumber = reader.ReadByte();
+			for (byte i = 0; i < ParameterNumber; i++)
+			{
+				Parameters[reader.ReadByte()] = reader.ReadBytes(4);
+			}
+            reader.ReadByte(); // Always 00
+
+            if (ActionType == 0x12 || ActionType == 0x19)
+            {
+                SwitchGroupId = reader.ReadUInt32();
+                SwitchId = reader.ReadUInt32();
+            }
+
+            Unhandled = reader.ReadBytes(amount + dataOffset - (int)reader.BaseStream.Position); // Leftover data
+		}
+
+		public override void Write(BinaryWriter writer) {
+			using var dataWriter = new BinaryWriter(new MemoryStream());
+
+			dataWriter.Write(ActionScope);
+			dataWriter.Write(ActionType);
+			dataWriter.Write(ObjectId);
+			dataWriter.Write(0x00);
+            dataWriter.Write(ParameterNumber);
+            for (byte i = 0; i < ParameterNumber; i++)
+            {
+                dataWriter.Write(Parameters.FirstOrDefault(x => x.Value == Parameters[i]).Key);
+                dataWriter.Write(Parameters[i]);
+            }
+            writer.Write(0x00);
+            if (ActionType == 0x12 || ActionType == 0x19)
+            {
+                dataWriter.Write(SwitchGroupId);
+                dataWriter.Write(SwitchId);
+            }
+
+			dataWriter.Write(Unhandled);
+			Data = (dataWriter.BaseStream as MemoryStream).ToArray();
+
+			base.Write(writer);
+		}
+	}
+}

--- a/SoundBank/Sections/HircObjects/Event.cs
+++ b/SoundBank/Sections/HircObjects/Event.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PD2SoundBankEditor {
+	public class Event : HircObject {
+		public uint ActionNumber;
+		public List<uint> ActionIDs = new();
+        
+		public byte[] Unhandled;
+
+		public Event(HircSection section, byte type, BinaryReader reader) : base(section, type, reader) { }
+
+		public override void Read(BinaryReader reader, int amount) {
+			var dataOffset = (int)reader.BaseStream.Position;
+
+            ActionNumber = reader.ReadUInt32();
+			for (var i = 0; i < ActionNumber; i++)
+			{
+                ActionIDs.Add(reader.ReadUInt32());
+			}
+
+            Unhandled = reader.ReadBytes(amount + dataOffset - (int)reader.BaseStream.Position); // Leftover data
+		}
+
+		public override void Write(BinaryWriter writer) {
+			using var dataWriter = new BinaryWriter(new MemoryStream());
+
+			dataWriter.Write(ActionNumber);
+			for (var i = 0; i < ActionNumber; i++)
+			{
+				dataWriter.Write(ActionIDs[i]);
+			}
+
+			dataWriter.Write(Unhandled);
+			Data = (dataWriter.BaseStream as MemoryStream).ToArray();
+
+			base.Write(writer);
+		}
+	}
+}

--- a/SoundBank/Sections/HircObjects/HircObject.cs
+++ b/SoundBank/Sections/HircObjects/HircObject.cs
@@ -56,7 +56,6 @@ namespace PD2SoundBankEditor {
 			StringId = type switch // Only try to dehash names for reversable types
 			{
 				0x04 => HashList.DehashId(Id),
-				0x06 => HashList.DehashId(Id),
 				0x08 => HashList.DehashId(Id),
 				_ => null
 			};

--- a/SoundBank/Sections/HircObjects/HircObject.cs
+++ b/SoundBank/Sections/HircObjects/HircObject.cs
@@ -17,6 +17,7 @@ namespace PD2SoundBankEditor {
 		public byte Type { get; protected set; }
 		public uint Size { get; protected set; }
 		public uint Id { get; protected set; }
+		public string StringId { get; protected set; }
 		public byte[] Data { get; protected set; }
 		public string TypeName {
 			get => Type switch {
@@ -26,8 +27,19 @@ namespace PD2SoundBankEditor {
 				0x05 => "Random/Sequence Container",
 				0x06 => "Switch Container",
 				0x07 => "Actor Mixer",
+				0x08 => "Audio Bus",
+				0x09 => "Blend Container",
+				0x0A => "Music Segment",
+				0x0B => "Music Track",
+				0x0C => "Music Switch Container",
+ 				0x0D => "Music Playlist Container",
 				0x0E => "Attenuation",
+				0x0F => "Dialogue Event",
+				0x10 => "Motion Bus",
+				0x11 => "Motion FX",
+				0x12 => "Effect",
 				0x13 => "FxCustom",
+				0x14 => "Auxiliary Bus",
 				_ => $"Unknown (0x{Type:x2})"
 			};
 		}
@@ -39,6 +51,13 @@ namespace PD2SoundBankEditor {
 			Type = type;
 			Size = reader.ReadUInt32();
 			Id = reader.ReadUInt32();
+			StringId = type switch // Only try to dehash names for reversable types
+			{
+				0x04 => HashList.DehashId(Id),
+				0x06 => HashList.DehashId(Id),
+				0x08 => HashList.DehashId(Id),
+				_ => null
+			};
 			Read(reader, (int)Size - sizeof(UInt32));
 		}
 

--- a/SoundBank/Sections/HircObjects/HircObject.cs
+++ b/SoundBank/Sections/HircObjects/HircObject.cs
@@ -7,6 +7,8 @@ namespace PD2SoundBankEditor {
 			var type = reader.ReadByte();
 			return type switch {
 				0x02 => new Sound(section, type, reader),
+				0x03 => new Action(section, type, reader),
+				0x04 => new Event(section, type, reader),
 				0x07 => new ActorMixer(section, type, reader),
 				_ => new HircObject(section, type, reader)
 			};

--- a/Util/HashList.cs
+++ b/Util/HashList.cs
@@ -1,0 +1,52 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Windows;
+
+namespace PD2SoundBankEditor
+{
+    public static class HashList
+    {
+        static private Dictionary<uint, string> MatchTable = new Dictionary<uint, string>();
+
+        static HashList()
+        {
+            var hashlistFile = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "hashlist");
+            if (!File.Exists(hashlistFile))
+            {
+                MessageBox.Show("ID hashlist not found in the application's directory; event names will be unavailable.", "Information", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+            List<string> strings = JsonConvert.DeserializeObject<List<string>>(File.ReadAllText(hashlistFile));
+            foreach (string s in strings)
+            {
+                MatchTable[FNVHash(s)] = s;
+            }
+        }
+
+        static private uint FNVHash(string name)
+        {
+            var namebytes = Encoding.UTF8.GetBytes(name);
+            var hash = 2166136261; // FNV initial offset
+
+            foreach (byte namebyte in namebytes)
+            {
+                hash = hash * 16777619; // FNV prime
+                hash = hash ^ namebyte;
+                hash = hash & 0xFFFFFFFF;
+            }
+
+            return hash;
+        }
+
+        static public string DehashId(uint id)
+        {
+            string stringId;
+            MatchTable.TryGetValue(id, out stringId);
+
+            return stringId;
+        }
+    }
+}

--- a/Util/HashList.cs
+++ b/Util/HashList.cs
@@ -28,7 +28,7 @@ namespace PD2SoundBankEditor
 
         static private uint FNVHash(string name)
         {
-            var namebytes = Encoding.UTF8.GetBytes(name);
+            var namebytes = Encoding.UTF8.GetBytes(name.ToLower());
             var hash = 2166136261; // FNV initial offset
 
             foreach (byte namebyte in namebytes)


### PR DESCRIPTION
Incorporated the missing types for the HIRC section mentioned in [this handy page](web.archive.org/web/20230818023606/http://wiki.xentax.com/index.php/Wwise_SoundBank_(*.bnk)) and added JSON [sound hashlist](https://modworkshop.net/mod/53326) lookup functionality to HIRC objects.

The latter ModWorkShop page includes a download to a file named `wwise-string-list.json` which is the JSON string array the `HashList` static class looks for under the name `hashlist`, just like how `MainWindow` looks for `wwise_ima_adpcm.exe`. Some extra info on reversable names can be found [here](https://github.com/bnnm/wwiser-utils/blob/master/doc/NAMES.md), although practically all of the available strings have already been added.

This is my first time using C#. If anything isn't up to standard, do let me know.

<img width="977" height="530" alt="imagen" src="https://github.com/user-attachments/assets/1dc0ba2f-f020-4947-bac3-2434071aa916" />

Adding dedicated object classes for Events and Actions would also be a nice touch. Maybe it can be made possible to add our own events? As an alternative to XAudio 😉